### PR TITLE
Prevent line breaks added by file_get_contents('php://stdin')

### DIFF
--- a/encrypt
+++ b/encrypt
@@ -4,7 +4,7 @@
 require_once(__DIR__.'/init.php');
 
 print encrypt_64(
-        file_get_contents('php://stdin'),
+        rtrim(file_get_contents('php://stdin'), "\n\r"),
         public_key(fetch_config())
     ) . "\n";
 


### PR DESCRIPTION
Hi! Thank you so much for the tool, it's awesome!

Apparently `file_get_contents('php://stdin')` adds a line break after reading the secret from STDIN, which provokes the secret to be invalid after decrypting.

This PR fixes the issue by trimming line breaks from the read string.